### PR TITLE
Added support for installation from gitee

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - K8s
   - Deployment
 engine: gotpl
-version: 0.10.10
+version: 0.11.0
 sources:
   - https://github.com/devtron-labs/charts
 maintainers:

--- a/charts/devtron/templates/devtron-installer.yaml
+++ b/charts/devtron/templates/devtron-installer.yaml
@@ -4,5 +4,9 @@ metadata:
   name: installer-devtron
   namespace: devtroncd
 spec:
+  {{- if or (eq .Values.installer.source "gitee") (eq .Values.installer.source "Gitee")}}
+  url: https://gitee.com/{{ .Values.installer.repo }}/raw/{{ .Values.installer.release }}/manifests/installation-script
+  {{- else }}
   url: https://raw.githubusercontent.com/{{ .Values.installer.repo }}/{{ .Values.installer.release }}/manifests/installation-script
+  {{- end }}
   reSync: true

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -5,6 +5,8 @@ installer:
   image: quay.io/devtron/inception
   tag: dee0d9a4-185-4689
 
+  source: "github"
+
 #Use secrets in plaintext, they'll be encoded to base64 automatically.
 secrets: {}
 #  If No POSTGRESQL_PASSWORD is provided, a password is automatically generated and saved in secret devtron-secret

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -1,11 +1,11 @@
 installer:
   repo: "devtron-labs/devtron"
-  release: "main"   #You can use a branch name or a release tag name as a release
+  release: "main" #You can use a branch name or a release tag name as a release, for gitee as source only "main" is supported as of now
 
   image: quay.io/devtron/inception
   tag: dee0d9a4-185-4689
 
-  source: "github"
+  source: "github" # Available options are github and gitee as of now
 
 #Use secrets in plaintext, they'll be encoded to base64 automatically.
 secrets: {}

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -5,7 +5,7 @@ installer:
   image: quay.io/devtron/inception
   tag: dee0d9a4-185-4689
 
-  source: "github" # Available options are github and gitee as of now
+  source: "github" # Available options are github and gitee
 
 #Use secrets in plaintext, they'll be encoded to base64 automatically.
 secrets: {}


### PR DESCRIPTION
Now if anyone uses any of the options with helm command, they will be redirected to devtron repository at gitee.com - --set installer.source=Gitee / --set installer.source="Gitee" / --set installer.source=gitee / --set installer.source="gitee"