### PR TITLE
FIX: Namespace filter fixed in EA only mode

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - argocd
   - Hyperion
 engine: gotpl
-version: 0.21.1
+version: 0.21.2
 sources:
   - https://github.com/devtron-labs/charts
 maintainers:

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -15,7 +15,7 @@ hyperion:
       hotjar: "false"
       sentry: "false"
       sentryEnv: "PRODUCTION"
-    image: "quay.io/devtron/dashboard:c7440255-6-6792"
+    image: "quay.io/devtron/dashboard:27445cfd-136-6798"
     imagePullPolicy: IfNotPresent
 
   devtron:


### PR DESCRIPTION
This PR fixes namespace filter API in hyperion mode when we switch from Apps list to Helm Apps or Vice Versa