### PR TITLE
Added support for cron auto restart in git-svn-sync

### DIFF
--- a/charts/svn-git-sync/Chart.yaml
+++ b/charts/svn-git-sync/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.1.1
+appVersion: 0.1.2
 description: This chart is used to sync SVN repo with a repo on remote git.
 maintainers:
 - email: pawan.mehta@devtron.ai
   name: Pawan Kumar
 name: svn-git-sync
-version: 0.1.1
+version: 0.1.2

--- a/charts/svn-git-sync/templates/deployment.yaml
+++ b/charts/svn-git-sync/templates/deployment.yaml
@@ -69,3 +69,16 @@ spec:
             - name: {{ .Release.Name }}-branches
               mountPath: /app/{{ $.Values.configs.REPO_NAME }}/
           {{- end }}
+        - name: {{ .Release.Name }}-cron
+          image: quay.io/devtron/svn-git-sync:cron
+          imagePullPolicy: {{ $.Values.imagePullPolicy }}
+          envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-cm
+          {{- if $.Values.persistence.enabled }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-volume
+              mountPath: /app
+          {{- end }}
+          
+          

--- a/charts/svn-git-sync/templates/deployment.yaml
+++ b/charts/svn-git-sync/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
             - name: {{ .Release.Name }}-branches
               mountPath: /app/{{ $.Values.configs.REPO_NAME }}/
           {{- end }}
+        {{- if .Values.autoRestart }}
         - name: {{ .Release.Name }}-cron
           image: quay.io/devtron/svn-git-sync:cron
           imagePullPolicy: {{ $.Values.imagePullPolicy }}
@@ -80,5 +81,6 @@ spec:
             - name: {{ .Release.Name }}-volume
               mountPath: /app
           {{- end }}
+        {{- end }}
           
           

--- a/charts/svn-git-sync/values.yaml
+++ b/charts/svn-git-sync/values.yaml
@@ -16,7 +16,7 @@ secrets:
 # If you want to sync only few branches and don't want to sync all branches, then mention those branches here
 CUSTOM_BRANCHES_TO_SYNC: []
 
-image: "quay.io/devtron/svn-git-sync:v6"
+image: "quay.io/devtron/svn-git-sync:v7"
 imagePullPolicy: "IfNotPresent"
 
 podLabels: {}

--- a/charts/svn-git-sync/values.yaml
+++ b/charts/svn-git-sync/values.yaml
@@ -22,6 +22,8 @@ imagePullPolicy: "IfNotPresent"
 podLabels: {}
 podAnnotations: {}
 
+autoRestart: false
+
 persistence:
   enabled: true
   size: "2Gi"


### PR DESCRIPTION
If SVN sync needs restart, this is a temporary solution for the same