### PR TITLE
Added RBAC for delete pod permission

### DIFF
--- a/charts/svn-git-sync/Chart.yaml
+++ b/charts/svn-git-sync/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.1.2
+appVersion: 0.1.3
 description: This chart is used to sync SVN repo with a repo on remote git.
 maintainers:
 - email: pawan.mehta@devtron.ai
   name: Pawan Kumar
 name: svn-git-sync
-version: 0.1.2
+version: 0.1.3

--- a/charts/svn-git-sync/templates/deployment.yaml
+++ b/charts/svn-git-sync/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             name: {{ .Release.Name }}-branches-cm
       {{- end }}
       terminationGracePeriodSeconds: 30
+      {{- if .Values.autoRestart }}
+      serviceAccountName: {{ .Release.Name }}
+      {{- end }}
       restartPolicy: Always
       containers:
         - name: {{ .Release.Name }}

--- a/charts/svn-git-sync/templates/rbac.yaml
+++ b/charts/svn-git-sync/templates/rbac.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.autoRestart }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    app: svn-git-sync
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    app: svn-git-sync
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    app: svn-git-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
Auto Restart feature was added to git-svn-sync but it wasn't working as the container didn't have required permissions to delete the pod
Added serviceAccount with the required permissions