### PR TITLE
fix: Revert labels from image-scanner in security chart

### DIFF
--- a/charts/security/Chart.yaml
+++ b/charts/security/Chart.yaml
@@ -15,7 +15,7 @@ maintaintainers:
     email: pawan.mehta@devtron.ai
 sources:
   - https://github.com/devtron-labs/charts
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.1"
 dependencies:
 - name: clair

--- a/charts/security/templates/image-scanner.yaml
+++ b/charts/security/templates/image-scanner.yaml
@@ -4,8 +4,12 @@ kind: Secret
 metadata:
   name: image-scanner-secret
   labels:
-    release: devtron
     app: image-scanner
+    release: {{ $.Release.Name }}
+    integration: security
+{{- if .labels }}
+{{ toYaml .labels | indent 4 }}    
+{{- end}} 
 type: Opaque
 {{- if .secrets }}
 data:
@@ -19,8 +23,12 @@ kind: ConfigMap
 metadata:
   name: image-scanner-cm
   labels:
-    release: devtron
     app: image-scanner
+    release: {{ $.Release.Name }}
+    integration: security
+{{- if .labels }}
+{{ toYaml .labels | indent 4 }}    
+{{- end}} 
 data:
 {{- if .configs}}
 {{ toYaml .configs | indent 2 }}
@@ -32,7 +40,11 @@ metadata:
   name: image-scanner-service
   labels:
     app: image-scanner
-    release: devtron
+    release: {{ $.Release.Name }}
+    integration: security
+{{- if .labels }}
+{{ toYaml .labels | indent 4 }}    
+{{- end}} 
 spec:
   type: ClusterIP
   ports:
@@ -42,6 +54,11 @@ spec:
       name: app
   selector:
     app: image-scanner
+    release: {{ $.Release.Name }}
+    integration: security
+{{- if .labels }}
+{{ toYaml .labels | indent 4 }}    
+{{- end}} 
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,12 +66,19 @@ metadata:
   name: image-scanner
   labels:
     app: image-scanner
-    release: devtron
+    release: {{ $.Release.Name }}
+    integration: security
+{{- if .labels }}
+{{ toYaml .labels | indent 4 }}    
+{{- end}} 
 spec:
   selector:
     matchLabels:
       app: image-scanner
       release: devtron
+{{- if .labels }}
+{{ toYaml .labels | indent 6 }}    
+{{- end}} 
   replicas: {{ .replicaCount }}
   minReadySeconds: 60
   template:
@@ -62,6 +86,10 @@ spec:
       labels:
         app: image-scanner
         release: devtron
+        integration: security
+{{- if .labels }}
+{{ toYaml .labels | indent 8 }}    
+{{- end}} 
     spec:
       terminationGracePeriodSeconds: 30
       restartPolicy: Always

--- a/charts/security/templates/image-scanner.yaml
+++ b/charts/security/templates/image-scanner.yaml
@@ -4,12 +4,8 @@ kind: Secret
 metadata:
   name: image-scanner-secret
   labels:
+    release: devtron
     app: image-scanner
-    release: {{ $.Release.Name }}
-    integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 4 }}    
-{{- end}} 
 type: Opaque
 {{- if .secrets }}
 data:
@@ -23,12 +19,8 @@ kind: ConfigMap
 metadata:
   name: image-scanner-cm
   labels:
+    release: devtron
     app: image-scanner
-    release: {{ $.Release.Name }}
-    integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 4 }}    
-{{- end}} 
 data:
 {{- if .configs}}
 {{ toYaml .configs | indent 2 }}
@@ -40,11 +32,7 @@ metadata:
   name: image-scanner-service
   labels:
     app: image-scanner
-    release: {{ $.Release.Name }}
-    integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 4 }}    
-{{- end}} 
+    release: devtron
 spec:
   type: ClusterIP
   ports:
@@ -54,11 +42,6 @@ spec:
       name: app
   selector:
     app: image-scanner
-    release: {{ $.Release.Name }}
-    integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 4 }}    
-{{- end}} 
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -66,31 +49,19 @@ metadata:
   name: image-scanner
   labels:
     app: image-scanner
-    release: {{ $.Release.Name }}
-    integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 4 }}    
-{{- end}} 
+    release: devtron
 spec:
   selector:
     matchLabels:
       app: image-scanner
-      release: {{ $.Release.Name }}
-      integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 6 }}    
-{{- end}} 
+      release: devtron
   replicas: {{ .replicaCount }}
   minReadySeconds: 60
   template:
     metadata:
       labels:
         app: image-scanner
-        release: {{ $.Release.Name }}
-        integration: security
-{{- if .labels }}
-{{ toYaml .labels | indent 8 }}    
-{{- end}} 
+        release: devtron
     spec:
       terminationGracePeriodSeconds: 30
       restartPolicy: Always


### PR DESCRIPTION
Revert labels from image-scanner in security chart