### PR TITLE
Global Node selector, Affinity and tolerations update

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - argocd
   - Hyperion
 engine: gotpl
-version: 0.22.51
+version: 0.22.52
 sources:
   - https://github.com/devtron-labs/charts
 dependencies:

--- a/charts/devtron/templates/app-sync-job.yaml
+++ b/charts/devtron/templates/app-sync-job.yaml
@@ -47,6 +47,22 @@ spec:
         {{- end }}
         {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.components.migrator }}
+      {{- if .Values.components.migrator.appSync }}
+      {{- with .Values.components.migrator.appSync.affinity | default .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.components.migrator.appSync.tolerations | default .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.components.migrator.appSync.nodeSelector | default .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
   backoffLimit: 4
 ---
 {{- end }}

--- a/charts/devtron/templates/dashboard.yaml
+++ b/charts/devtron/templates/dashboard.yaml
@@ -69,6 +69,18 @@ spec:
     spec:
       terminationGracePeriodSeconds: 30
       restartPolicy: Always
+      {{- with $.Values.components.dashboard.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.dashboard.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.dashboard.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: dashboard
           image: {{ .image }}

--- a/charts/devtron/templates/devtron.yaml
+++ b/charts/devtron/templates/devtron.yaml
@@ -97,6 +97,18 @@ spec:
       terminationGracePeriodSeconds: 30
       restartPolicy: Always
       serviceAccountName: devtron
+      {{- with .Values.components.devtron.affinity | default .Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.components.devtron.tolerations | default .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.components.devtron.nodeSelector | default .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: devtron
           {{- if $.Values.installer.modules }}

--- a/charts/devtron/templates/dex.yaml
+++ b/charts/devtron/templates/dex.yaml
@@ -68,6 +68,14 @@ spec:
                   app.kubernetes.io/part-of: argocd
               topologyKey: kubernetes.io/hostname
             weight: 5
+      {{- with $.Values.components.argocdDexServer.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.argocdDexServer.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - command:
         - /shared/authenticator

--- a/charts/devtron/templates/grafana.yaml
+++ b/charts/devtron/templates/grafana.yaml
@@ -15,6 +15,18 @@ spec:
   template:
     spec:
       serviceAccountName: devtron
+      {{- with $.Values.monitoring.grafana.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.monitoring.grafana.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.monitoring.grafana.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: grafana-restart
         image: "quay.io/devtron/kubectl:latest"
@@ -660,6 +672,18 @@ metadata:
   namespace: devtroncd
 spec:
   serviceAccountName: devtron-grafana-test
+  {{- with $.Values.monitoring.grafana.affinity | default $.Values.global.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.monitoring.grafana.tolerations | default $.Values.global.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.monitoring.grafana.nodeSelector | default $.Values.global.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: devtron-test
       image: "quay.io/devtron/bats:v1.4.1"

--- a/charts/devtron/templates/install.yaml
+++ b/charts/devtron/templates/install.yaml
@@ -108,6 +108,18 @@ spec:
           {{- end }}    
       restartPolicy: Always
       serviceAccountName: installer
+      {{- with $.Values.installer.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.installer.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.installer.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
 {{- end }}
 {{- end }}

--- a/charts/devtron/templates/kubelink.yaml
+++ b/charts/devtron/templates/kubelink.yaml
@@ -21,6 +21,18 @@ spec:
     spec:
       terminationGracePeriodSeconds: 30
       restartPolicy: Always
+      {{- with $.Values.components.kubelink.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.kubelink.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.kubelink.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: devtron
       containers:
         - name: kubelink

--- a/charts/devtron/templates/migrator.yaml
+++ b/charts/devtron/templates/migrator.yaml
@@ -48,6 +48,18 @@ spec:
         {{- end }}
         {{- end }}           
       restartPolicy: OnFailure
+      {{- with $.Values.components.migrator.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.migrator.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.migrator.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 20
   activeDeadlineSeconds: 1500
 ---
@@ -113,6 +125,18 @@ spec:
             memory: 500Mi
         {{- end }}                     
       restartPolicy: OnFailure
+      {{- with $.Values.components.migrator.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.migrator.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.migrator.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 20
   activeDeadlineSeconds: 1500
 {{- end }}

--- a/charts/devtron/templates/minio.yaml
+++ b/charts/devtron/templates/minio.yaml
@@ -260,6 +260,18 @@ spec:
         release: {{ $.Release.Name }}
     spec:
       serviceAccountName: "devtron-minio"
+      {{- with $.Values.minio.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.minio.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.minio.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -337,6 +349,18 @@ spec:
               - secret:
                   name: devtron-minio
       serviceAccountName: "devtron-minio"
+      {{- with $.Values.minio.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.minio.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.minio.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: minio-mc
           image: {{ $.Values.minio.mbImage }}
@@ -383,6 +407,18 @@ spec:
         release: devtron-minio
     spec:
       serviceAccountName: "devtron-minio"
+      {{- with $.Values.minio.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.minio.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.minio.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: minio
           image: "quay.io/devtron/minio:RELEASE.2020-12-03T05-49-24Z"

--- a/charts/devtron/templates/notifier.yaml
+++ b/charts/devtron/templates/notifier.yaml
@@ -74,6 +74,18 @@ spec:
     spec:
       terminationGracePeriodSeconds: 30
       restartPolicy: Always
+      {{- with $.Values.notifier.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.notifier.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.notifier.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: notifier
           image: {{ .image }}

--- a/charts/devtron/templates/postgresql.yaml
+++ b/charts/devtron/templates/postgresql.yaml
@@ -115,6 +115,18 @@ spec:
     spec:
       securityContext:
         fsGroup: 1001
+      {{- with $.Values.components.postgres.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.postgres.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.postgres.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-chmod-data
           image: "quay.io/devtron/minideb:latest"
@@ -444,6 +456,18 @@ spec:
     spec:
       securityContext:
         fsGroup: 999
+      {{- with $.Values.components.postgres.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.postgres.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.components.postgres.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: postgres-init
           securityContext:

--- a/charts/devtron/templates/workflow.yaml
+++ b/charts/devtron/templates/workflow.yaml
@@ -363,6 +363,18 @@ spec:
       labels:
         app: workflow-controller
     spec:
+      {{- with $.Values.workflowController.affinity | default $.Values.global.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.workflowController.tolerations | default $.Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.workflowController.nodeSelector | default $.Values.global.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - --configmap

--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -308,3 +308,8 @@ monitoring:
       resources: {}
     persistence:
       storage: "2Gi"
+      
+global:    
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/charts/discord-alertmanager/Chart.yaml
+++ b/charts/discord-alertmanager/Chart.yaml
@@ -1,7 +1,7 @@
 name: discord-alertmanager
 description: Helm chart to deploy webhook integration for sending alert manager alerts on discord.
-version: 0.10.0
-appVersion: 0.1.0
+version: 0.11.0
+appVersion: 0.2.0
 maintainers:
 - email: ajay@devtron.ai
   name: Ajay

--- a/charts/discord-alertmanager/templates/deployment.yaml
+++ b/charts/discord-alertmanager/templates/deployment.yaml
@@ -31,4 +31,11 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        
+      {{- with $.Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{ if $.Values.affinity }}
+      affinity:
+          {{ toYaml $.Values.affinity | indent 10 }}
+          {{- end }}

--- a/charts/discord-alertmanager/templates/deployment.yaml
+++ b/charts/discord-alertmanager/templates/deployment.yaml
@@ -37,5 +37,5 @@ spec:
       {{- end }}
       {{ if $.Values.affinity }}
       affinity:
-          {{ toYaml $.Values.affinity | indent 10 }}
+{{ toYaml $.Values.affinity | indent 8 }}
           {{- end }}

--- a/charts/discord-alertmanager/values.yaml
+++ b/charts/discord-alertmanager/values.yaml
@@ -30,22 +30,22 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-tolerations: 
-  - key: "key1"
-    operator: "Equal"
-    value: "value1"
-    effect: "NoSchedule"
+tolerations: []
+  # - key: "key1"
+  #   operator: "Equal"
+  #   value: "value1"
+  #   effect: "NoSchedule"
 
-affinity: 
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: topology.kubernetes.io/zone
-          operator: In
-          values:
-          - us-east-2a
-        - key: topology.kubernetes.io/region
-          operator: In
-          values:
-          - us-east-2
+affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: topology.kubernetes.io/zone
+  #         operator: In
+  #         values:
+  #         - us-east-2a
+  #       - key: topology.kubernetes.io/region
+  #         operator: In
+  #         values:
+  #         - us-east-2

--- a/charts/discord-alertmanager/values.yaml
+++ b/charts/discord-alertmanager/values.yaml
@@ -29,3 +29,22 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+tolerations: []
+# - key: "key1"
+#   operator: "Equal"
+#   value: "value1"
+#   effect: "NoSchedule"
+
+affinity: {}
+ # nodeAffinity:
+      #   required:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: topology.kubernetes.io/zone
+      #         operator: In
+      #         values:
+      #         - us-east-2a
+      #       - key: topology.kubernetes.io/region
+      #         operator: In
+      #         values:
+      #         - us-east-2

--- a/charts/discord-alertmanager/values.yaml
+++ b/charts/discord-alertmanager/values.yaml
@@ -29,22 +29,23 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-tolerations: []
-# - key: "key1"
-#   operator: "Equal"
-#   value: "value1"
-#   effect: "NoSchedule"
 
-affinity: {}
- # nodeAffinity:
-      #   required:
-      #     nodeSelectorTerms:
-      #     - matchExpressions:
-      #       - key: topology.kubernetes.io/zone
-      #         operator: In
-      #         values:
-      #         - us-east-2a
-      #       - key: topology.kubernetes.io/region
-      #         operator: In
-      #         values:
-      #         - us-east-2
+tolerations: 
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+
+affinity: 
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values:
+          - us-east-2a
+        - key: topology.kubernetes.io/region
+          operator: In
+          values:
+          - us-east-2


### PR DESCRIPTION
here, i have added a `global` term in values.yaml which contains  Node selector, Affinity and tolerations.
these values are used by jobs, deployments, pods and statefulset throughout the chart.