### PR TITLE
changed http to https for helm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Charts with its functionality is listed below:
 These charts are currently not available on the official helm repository therefore you need to download it to install.
 
 ```bash
-helm repo add devtron http://helm.devtron.ai
+helm repo add devtron https://helm.devtron.ai
 helm install Chart-Release-Name devtron/chartName
 ```
 


### PR DESCRIPTION
there is one change in `helm repo add devtron http://helm.devtron.ai/` , here the command
 need  https , as in git-repo https://github.com/devtron-labs/devtron/blob/main/charts/devtron/Chart.yaml, we stated in dependencies that https://helm.devtron.ai