### PR TITLE
fix: devtron-backup helm chart for GCP 

### DIFF
--- a/charts/devtron-backups/Chart.yaml
+++ b/charts/devtron-backups/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Devtron Backups
 name: devtron-backups
-version: 0.1.5
+version: 0.1.6

--- a/charts/devtron-backups/templates/backup-on-gcp.yaml
+++ b/charts/devtron-backups/templates/backup-on-gcp.yaml
@@ -53,7 +53,7 @@ spec:
             - name: GCS_BUCKET
               value: "gs://{{ .GCS_BUCKET_NAME }}"
             {{- if .CREDENTIALS.enabled }}
-            - name: gcp-credentials
+            - name: gcp_credentials
               valueFrom:
                 secretKeyRef:
                   name: gcp-credentials
@@ -64,12 +64,10 @@ spec:
             args:
             - /bin/bash
             - -c
-            - echo $gcp-credentials > /tmp/gcp-credentials.json
-            - gcloud auth activate-service-account --key-file=/tmp/gcp-credentials.json            
           {{- if $.Values.global.GCP.encryption.enabled }}          
-            - date1=$(date +%Y%m%d-%H%M); gpg -c --batch --passphrase {{ .Values.global.GCP.encryption.passphrase }} /tmp/backup.tar; rm -rvf /tmp/backup.tar; mv /tmp/backup.tar.gpg /tmp/backup-$date1.tar.gpg; gcloud storage cp /tmp/backup-$date1.tar.gpg $GCS_BUCKET/postgres/;
+            - echo $gcp_credentials > /tmp/gcp_credentials.json ; gcloud auth activate-service-account --key-file=/tmp/gcp_credentials.json ; date1=$(date +%Y%m%d-%H%M); gpg -c --batch --passphrase {{ .Values.global.GCP.encryption.passphrase }} /tmp/backup.tar; rm -rvf /tmp/backup.tar; mv /tmp/backup.tar.gpg /tmp/backup-$date1.tar.gpg; gcloud storage cp /tmp/backup-$date1.tar.gpg $GCS_BUCKET/postgres/;
           {{- else}}
-            - date1=$(date +%Y%m%d-%H%M); mv /tmp/backup.tar /tmp/backup-$date1.tar; gcloud storage cp /tmp/backup-$date1.tar $GCS_BUCKET/postgres/;
+            - echo $gcp_credentials > /tmp/gcp_credentials.json ; gcloud auth activate-service-account --key-file=/tmp/gcp_credentials.json ; date1=$(date +%Y%m%d-%H%M); mv /tmp/backup.tar /tmp/backup-$date1.tar; gcloud storage cp /tmp/backup-$date1.tar $GCS_BUCKET/postgres/;
           {{- end }}
           volumes:
           - name: psql-volume
@@ -125,7 +123,7 @@ spec:
             - name: GCS_BUCKET
               value: "gs://{{ .GCS_BUCKET_NAME }}"
             {{- if .CREDENTIALS.enabled }}
-            - name: gcp-credentials
+            - name: gcp_credentials
               valueFrom:
                 secretKeyRef:
                   name: gcp-credentials
@@ -136,12 +134,10 @@ spec:
             args:
             - /bin/bash
             - -c
-            - echo $gcp-credentials > /tmp/gcp-credentials.json
-            - gcloud auth activate-service-account --key-file=/tmp/gcp-credentials.json
           {{- if $.Values.global.GCP.encryption.enabled }}
-            - date1=$(date +%Y%m%d-%H%M); gpg -c --batch --passphrase {{ .Values.global.GCP.encryption.passphrase }} /cache/backup.yaml; rm -rvf /cache/backup.yaml; mv /cache/backup.yaml.gpg /cache/backup-$date1.yaml.gpg; gcloud storage cp /cache/backup-$date1.yaml.gpg $GCS_BUCKET/argocd/;
+            - echo $gcp_credentials > /tmp/gcp_credentials.json ; gcloud auth activate-service-account --key-file=/tmp/gcp_credentials.json ; date1=$(date +%Y%m%d-%H%M); gpg -c --batch --passphrase {{ .Values.global.GCP.encryption.passphrase }} /cache/backup.yaml; rm -rvf /cache/backup.yaml; mv /cache/backup.yaml.gpg /cache/backup-$date1.yaml.gpg; gcloud storage cp /cache/backup-$date1.yaml.gpg $GCS_BUCKET/argocd/;
           {{- else}}
-            - date1=$(date +%Y%m%d-%H%M); mv /cache/backup.yaml /cache/backup-$date1.yaml; gcloud storage cp /cache/backup-$date1.yaml $GCS_BUCKET/argocd/;
+            - echo $gcp_credentials > /tmp/gcp_credentials.json ; gcloud auth activate-service-account --key-file=/tmp/gcp_credentials.json ; date1=$(date +%Y%m%d-%H%M); mv /cache/backup.yaml /cache/backup-$date1.yaml; gcloud storage cp /cache/backup-$date1.yaml $GCS_BUCKET/argocd/;
           {{- end }}
           volumes:
           - name: argocd-volume

--- a/charts/devtron-backups/templates/backup-on-gcp.yaml
+++ b/charts/devtron-backups/templates/backup-on-gcp.yaml
@@ -64,6 +64,8 @@ spec:
             args:
             - /bin/bash
             - -c
+            - echo $gcp-credentials > /tmp/gcp-credentials.json
+            - gcloud auth activate-service-account --key-file=/tmp/gcp-credentials.json            
           {{- if $.Values.global.GCP.encryption.enabled }}          
             - date1=$(date +%Y%m%d-%H%M); gpg -c --batch --passphrase {{ .Values.global.GCP.encryption.passphrase }} /tmp/backup.tar; rm -rvf /tmp/backup.tar; mv /tmp/backup.tar.gpg /tmp/backup-$date1.tar.gpg; gcloud storage cp /tmp/backup-$date1.tar.gpg $GCS_BUCKET/postgres/;
           {{- else}}
@@ -134,6 +136,8 @@ spec:
             args:
             - /bin/bash
             - -c
+            - echo $gcp-credentials > /tmp/gcp-credentials.json
+            - gcloud auth activate-service-account --key-file=/tmp/gcp-credentials.json
           {{- if $.Values.global.GCP.encryption.enabled }}
             - date1=$(date +%Y%m%d-%H%M); gpg -c --batch --passphrase {{ .Values.global.GCP.encryption.passphrase }} /cache/backup.yaml; rm -rvf /cache/backup.yaml; mv /cache/backup.yaml.gpg /cache/backup-$date1.yaml.gpg; gcloud storage cp /cache/backup-$date1.yaml.gpg $GCS_BUCKET/argocd/;
           {{- else}}

--- a/charts/devtron-backups/values.yaml
+++ b/charts/devtron-backups/values.yaml
@@ -29,7 +29,7 @@ global:
     
     encryption:
       enabled: false # Recommended
-      passphrase: ""
+      passphrase: "" # Required if encryption is enabled
 
 argocdversion: v2
     


### PR DESCRIPTION
- added command to authorise the service account passed as JSON credentials
- added all the steps being executed as single command arg