### PR TITLE
Sync changes from https://github.com/devtron-labs/devtron.git for release 1.5.0

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - argocd
   - Hyperion
 engine: gotpl
-version: 0.22.90
+version: 0.22.91
 sources:
   - https://github.com/devtron-labs/charts
 dependencies:

--- a/charts/devtron/templates/configmap-secret.yaml
+++ b/charts/devtron/templates/configmap-secret.yaml
@@ -377,3 +377,15 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if $.Values.devtronEnterprise.enabled }}
+---
+apiVersion: v1
+data:
+{{- if or $.Values.UCID $.Values.ucid }}
+  UCID: {{ $.Values.UCID | default $.Values.ucid }}
+{{- end }}
+kind: ConfigMap
+metadata:
+  name: devtron-ucid
+  namespace: devtroncd
+{{- end }}


### PR DESCRIPTION
This pull request syncs changes from https://github.com/devtron-labs/devtron.git for release 1.5.0.