### PR TITLE
Sync changes from https://github.com/devtron-labs/devtron.git for release 1.5.0

### DIFF
--- a/charts/devtron/Chart.yaml
+++ b/charts/devtron/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - argocd
   - Hyperion
 engine: gotpl
-version: 0.22.91
+version: 0.22.92
 sources:
   - https://github.com/devtron-labs/charts
 dependencies:

--- a/charts/devtron/templates/configmap-secret.yaml
+++ b/charts/devtron/templates/configmap-secret.yaml
@@ -378,14 +378,16 @@ data:
 {{- end }}
 {{- end }}
 {{- if $.Values.devtronEnterprise.enabled }}
+{{- if or $.Values.UCID $.Values.ucid }}
 ---
 apiVersion: v1
 data:
-{{- if or $.Values.UCID $.Values.ucid }}
   UCID: {{ $.Values.UCID | default $.Values.ucid }}
-{{- end }}
 kind: ConfigMap
 metadata:
   name: devtron-ucid
   namespace: devtroncd
+  annotations:
+    "helm.sh/hook": pre-install
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This pull request syncs changes from https://github.com/devtron-labs/devtron.git for release 1.5.0.